### PR TITLE
#40 Redesign the operator cache ratio.

### DIFF
--- a/src/main/java/com/github/javabdd/BDDFactory.java
+++ b/src/main/java/com/github/javabdd/BDDFactory.java
@@ -417,7 +417,8 @@ public abstract class BDDFactory {
 
     /**
      * Sets the cache ratio for the operator caches. When the node table grows, operator caches will also grow to
-     * maintain the ratio.
+     * maintain the ratio. A ratio of {@code 0.5} leads to caches that are half the node table size, while a ratio
+     * of {@code 2.0} leads to caches that are twice the node table size.
      *
      * <p>
      * Compare to bdd_setcacheratio.

--- a/src/main/java/com/github/javabdd/JFactory.java
+++ b/src/main/java/com/github/javabdd/JFactory.java
@@ -434,7 +434,7 @@ public class JFactory extends BDDFactoryIntImpl {
 
     @Override
     public double setCacheRatio(double x) {
-        return bdd_setcacheratio((int)x);
+        return bdd_setcacheratio(x);
     }
 
     @Override
@@ -4726,7 +4726,7 @@ public class JFactory extends BDDFactoryIntImpl {
 
     BddCache countcache; /* Cache for count results */
 
-    int cacheratio;
+    double cacheratio;
 
     boolean satPolarity;
 
@@ -4817,7 +4817,7 @@ public class JFactory extends BDDFactoryIntImpl {
 
     void bdd_operator_noderesize() {
         if (cacheratio > 0) {
-            int newcachesize = bddnodesize / cacheratio;
+            int newcachesize = (int)(bddnodesize * cacheratio);
 
             BddCache_resize(applycache, newcachesize);
             BddCache_resize(itecache, newcachesize);
@@ -6088,8 +6088,8 @@ public class JFactory extends BDDFactoryIntImpl {
         return old;
     }
 
-    int bdd_setcacheratio(int r) {
-        int old = cacheratio;
+    double bdd_setcacheratio(double r) {
+        double old = cacheratio;
 
         if (r <= 0) {
             return bdd_error(BDD_RANGE);


### PR DESCRIPTION
- Keep the `double` as long as possible, for higher precision.
- Invert the meaning of the cache ratio.
- Improve the JavaDoc to explain the semantics of the cache ratio.

Fixes #40