### PR TITLE
#39 improve copyright statement

### DIFF
--- a/.checkstyle
+++ b/.checkstyle
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-Copyright (c) 2021-2023 John Whaley and com.github.javabdd contributors
+Copyright (c) 2021-2024 John Whaley and com.github.javabdd contributors
 
 See the CONTRIBUTORS file(s) distributed with this work for additional
 information regarding copyright ownership.

--- a/.checkstyle
+++ b/.checkstyle
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-Copyright (c) 2021-2023 John Whaley and others
+Copyright (c) 2021-2023 John Whaley and com.github.javabdd contributors
 
 See the CONTRIBUTORS file(s) distributed with this work for additional
 information regarding copyright ownership.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2020-2023 John Whaley and others
+# Copyright (c) 2020-2023 John Whaley and com.github.javabdd contributors
 #
 # See the CONTRIBUTORS file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2020-2023 John Whaley and com.github.javabdd contributors
+# Copyright (c) 2020-2024 John Whaley and com.github.javabdd contributors
 #
 # See the CONTRIBUTORS file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2020-2023 John Whaley and others
+# Copyright (c) 2020-2023 John Whaley and com.github.javabdd contributors
 #
 # See the CONTRIBUTORS file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2020-2023 John Whaley and com.github.javabdd contributors
+# Copyright (c) 2020-2024 John Whaley and com.github.javabdd contributors
 #
 # See the CONTRIBUTORS file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2020-2023 John Whaley and com.github.javabdd contributors
+Copyright (c) 2020-2024 John Whaley and com.github.javabdd contributors
 
 See the CONTRIBUTORS file(s) distributed with this work for additional
 information regarding copyright ownership.

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2020-2023 John Whaley and others
+Copyright (c) 2020-2023 John Whaley and com.github.javabdd contributors
 
 See the CONTRIBUTORS file(s) distributed with this work for additional
 information regarding copyright ownership.

--- a/release-perform
+++ b/release-perform
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 ##############################################################################
-# Copyright (c) 2020-2023 John Whaley and others
+# Copyright (c) 2020-2023 John Whaley and com.github.javabdd contributors
 #
 # See the CONTRIBUTORS file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/release-perform
+++ b/release-perform
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 ##############################################################################
-# Copyright (c) 2020-2023 John Whaley and com.github.javabdd contributors
+# Copyright (c) 2020-2024 John Whaley and com.github.javabdd contributors
 #
 # See the CONTRIBUTORS file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/release-prepare
+++ b/release-prepare
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 ##############################################################################
-# Copyright (c) 2020-2023 John Whaley and others
+# Copyright (c) 2020-2023 John Whaley and com.github.javabdd contributors
 #
 # See the CONTRIBUTORS file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/release-prepare
+++ b/release-prepare
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 ##############################################################################
-# Copyright (c) 2020-2023 John Whaley and com.github.javabdd contributors
+# Copyright (c) 2020-2024 John Whaley and com.github.javabdd contributors
 #
 # See the CONTRIBUTORS file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDD.java
+++ b/src/main/java/com/github/javabdd/BDD.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2003-2023 John Whaley and com.github.javabdd contributors
+// Copyright (c) 2003-2024 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDD.java
+++ b/src/main/java/com/github/javabdd/BDD.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2003-2023 John Whaley and others
+// Copyright (c) 2003-2023 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDDBitVector.java
+++ b/src/main/java/com/github/javabdd/BDDBitVector.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2003-2023 John Whaley and com.github.javabdd contributors
+// Copyright (c) 2003-2024 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDDBitVector.java
+++ b/src/main/java/com/github/javabdd/BDDBitVector.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2003-2023 John Whaley and others
+// Copyright (c) 2003-2023 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDDDomain.java
+++ b/src/main/java/com/github/javabdd/BDDDomain.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2003-2023 John Whaley and com.github.javabdd contributors
+// Copyright (c) 2003-2024 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDDDomain.java
+++ b/src/main/java/com/github/javabdd/BDDDomain.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2003-2023 John Whaley and others
+// Copyright (c) 2003-2023 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDDException.java
+++ b/src/main/java/com/github/javabdd/BDDException.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2003-2023 John Whaley and com.github.javabdd contributors
+// Copyright (c) 2003-2024 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDDException.java
+++ b/src/main/java/com/github/javabdd/BDDException.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2003-2023 John Whaley and others
+// Copyright (c) 2003-2023 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDDFactory.java
+++ b/src/main/java/com/github/javabdd/BDDFactory.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2003-2023 John Whaley and com.github.javabdd contributors
+// Copyright (c) 2003-2024 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDDFactory.java
+++ b/src/main/java/com/github/javabdd/BDDFactory.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2003-2023 John Whaley and others
+// Copyright (c) 2003-2023 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDDFactoryIntImpl.java
+++ b/src/main/java/com/github/javabdd/BDDFactoryIntImpl.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2004-2023 John Whaley and others
+// Copyright (c) 2004-2023 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDDFactoryIntImpl.java
+++ b/src/main/java/com/github/javabdd/BDDFactoryIntImpl.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2004-2023 John Whaley and com.github.javabdd contributors
+// Copyright (c) 2004-2024 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDDPairing.java
+++ b/src/main/java/com/github/javabdd/BDDPairing.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2003-2023 John Whaley and com.github.javabdd contributors
+// Copyright (c) 2003-2024 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDDPairing.java
+++ b/src/main/java/com/github/javabdd/BDDPairing.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2003-2023 John Whaley and others
+// Copyright (c) 2003-2023 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDDVarSet.java
+++ b/src/main/java/com/github/javabdd/BDDVarSet.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2004-2023 John Whaley and others
+// Copyright (c) 2004-2023 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BDDVarSet.java
+++ b/src/main/java/com/github/javabdd/BDDVarSet.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2004-2023 John Whaley and com.github.javabdd contributors
+// Copyright (c) 2004-2024 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BitString.java
+++ b/src/main/java/com/github/javabdd/BitString.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2001-2023 John Whaley and others
+// Copyright (c) 2001-2023 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/BitString.java
+++ b/src/main/java/com/github/javabdd/BitString.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2001-2023 John Whaley and com.github.javabdd contributors
+// Copyright (c) 2001-2024 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/FindBestOrder.java
+++ b/src/main/java/com/github/javabdd/FindBestOrder.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2004-2023 John Whaley and others
+// Copyright (c) 2004-2023 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/FindBestOrder.java
+++ b/src/main/java/com/github/javabdd/FindBestOrder.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2004-2023 John Whaley and com.github.javabdd contributors
+// Copyright (c) 2004-2024 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/JFactory.java
+++ b/src/main/java/com/github/javabdd/JFactory.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2003-2023 John Whaley and com.github.javabdd contributors
+// Copyright (c) 2003-2024 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/JFactory.java
+++ b/src/main/java/com/github/javabdd/JFactory.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2003-2023 John Whaley and others
+// Copyright (c) 2003-2023 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/TryVarOrder.java
+++ b/src/main/java/com/github/javabdd/TryVarOrder.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2004-2023 John Whaley and others
+// Copyright (c) 2004-2023 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/main/java/com/github/javabdd/TryVarOrder.java
+++ b/src/main/java/com/github/javabdd/TryVarOrder.java
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2004-2023 John Whaley and com.github.javabdd contributors
+// Copyright (c) 2004-2024 John Whaley and com.github.javabdd contributors
 //
 // See the CONTRIBUTORS file(s) distributed with this work for additional
 // information regarding copyright ownership.


### PR DESCRIPTION
* Copyright headers: `others` -> `com.github.javabdd contributors`.
* Update copyright year to 2024.