### PR TITLE
#67 BDD.pathCount/satCount return a BigInteger.

### DIFF
--- a/src/main/java/com/github/javabdd/BDD.java
+++ b/src/main/java/com/github/javabdd/BDD.java
@@ -14,6 +14,7 @@
 package com.github.javabdd;
 
 import java.io.PrintStream;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -1443,7 +1444,7 @@ public abstract class BDD {
      *
      * @return the number of paths leading to the true terminal
      */
-    public abstract double pathCount();
+    public abstract BigInteger pathCount();
 
     /**
      * Calculates the number of satisfying variable assignments.
@@ -1454,7 +1455,7 @@ public abstract class BDD {
      *
      * @return the number of satisfying variable assignments
      */
-    public abstract double satCount();
+    public abstract BigInteger satCount();
 
     /**
      * Calculates the number of satisfying variable assignments to the variables in the given varset. ASSUMES THAT THE
@@ -1468,18 +1469,19 @@ public abstract class BDD {
      * @param varset the given varset
      * @return the number of satisfying variable assignments
      */
-    public double satCount(BDDVarSet varset) {
+    public BigInteger satCount(BDDVarSet varset) {
         BDDFactory factory = getFactory();
 
         if (varset.isEmpty() || isZero()) { /* empty set */
-            return 0.;
+            return BigInteger.ZERO;
         }
 
-        double unused = factory.varNum();
+        int unused = factory.varNum();
         unused -= varset.size();
-        unused = satCount() / Math.pow(2.0, unused);
+        BigDecimal unused2 = new BigDecimal(satCount()).divide(new BigDecimal(BigInteger.TWO.pow(unused)));
 
-        return unused >= 1.0 ? unused : 1.0;
+        BigDecimal rslt = unused2.compareTo(BigDecimal.ONE) >= 0 ? unused2 : BigDecimal.ONE;
+        return rslt.toBigIntegerExact();
     }
 
     /**
@@ -1489,10 +1491,14 @@ public abstract class BDD {
      * Compare to bdd_satcount.
      * </p>
      *
+     * <p>
+     * Note that this returns a double, so it has more limited precision.
+     * </p>
+     *
      * @return the logarithm of the number of satisfying variable assignments
      */
     public double logSatCount() {
-        return Math.log(satCount());
+        return Math.log(satCount().doubleValue());
     }
 
     /**
@@ -1502,11 +1508,15 @@ public abstract class BDD {
      * Compare to bdd_satcountset.
      * </p>
      *
+     * <p>
+     * Note that this returns a double, so it has more limited precision.
+     * </p>
+     *
      * @param varset the given varset
      * @return the logarithm of the number of satisfying variable assignments
      */
     public double logSatCount(BDDVarSet varset) {
-        return Math.log(satCount(varset));
+        return Math.log(satCount(varset).doubleValue());
     }
 
     /**

--- a/src/main/java/com/github/javabdd/BDDDomain.java
+++ b/src/main/java/com/github/javabdd/BDDDomain.java
@@ -405,7 +405,7 @@ public abstract class BDDDomain {
      */
     public BigInteger[] getVarIndices(BDD that, int max) {
         BDDVarSet myvarset = set(); // can't use var here, must respect subclass a factory may provide
-        int n = (int)that.satCount(myvarset);
+        int n = that.satCount(myvarset).intValueExact();
         if (max != -1 && n > max) {
             n = max;
         }

--- a/src/main/java/com/github/javabdd/BDDFactoryIntImpl.java
+++ b/src/main/java/com/github/javabdd/BDDFactoryIntImpl.java
@@ -13,6 +13,7 @@
 
 package com.github.javabdd;
 
+import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -117,9 +118,9 @@ public abstract class BDDFactoryIntImpl extends BDDFactory {
 
     protected abstract int nodeCount_impl(/* bdd */int v);
 
-    protected abstract double pathCount_impl(/* bdd */int v);
+    protected abstract BigInteger pathCount_impl(/* bdd */int v);
 
-    protected abstract double satCount_impl(/* bdd */int v);
+    protected abstract BigInteger satCount_impl(/* bdd */int v);
 
     protected abstract /* bdd */int satOne_impl(/* bdd */int v);
 
@@ -269,7 +270,7 @@ public abstract class BDDFactoryIntImpl extends BDDFactory {
         }
 
         @Override
-        public double pathCount() {
+        public BigInteger pathCount() {
             return pathCount_impl(v);
         }
 
@@ -306,7 +307,7 @@ public abstract class BDDFactoryIntImpl extends BDDFactory {
         }
 
         @Override
-        public double satCount() {
+        public BigInteger satCount() {
             return satCount_impl(v);
         }
 

--- a/src/main/java/com/github/javabdd/JFactory.java
+++ b/src/main/java/com/github/javabdd/JFactory.java
@@ -1099,8 +1099,11 @@ public class JFactory extends BDDFactoryIntImpl {
         BddCache copy() {
             BddCache that = new BddCache();
             boolean is_d = this.table instanceof BddCacheDataD[];
+            boolean is_bi = this.table instanceof BddCacheDataBI[];
             if (is_d) {
                 that.table = new BddCacheDataD[this.table.length];
+            } else if (is_bi) {
+                that.table = new BddCacheDataBI[this.table.length];
             } else {
                 that.table = new BddCacheDataI[this.table.length];
             }

--- a/src/main/java/com/github/javabdd/JFactory.java
+++ b/src/main/java/com/github/javabdd/JFactory.java
@@ -1063,20 +1063,6 @@ public class JFactory extends BDDFactoryIntImpl {
         }
     }
 
-    private static class BddCacheDataD extends BddCacheData {
-        double dres;
-
-        @Override
-        BddCacheData copy() {
-            BddCacheDataD that = new BddCacheDataD();
-            that.a = this.a;
-            that.b = this.b;
-            that.c = this.c;
-            that.dres = this.dres;
-            return that;
-        }
-    }
-
     private static class BddCacheDataBI extends BddCacheData {
         BigInteger bires;
 
@@ -1098,11 +1084,8 @@ public class JFactory extends BDDFactoryIntImpl {
 
         BddCache copy() {
             BddCache that = new BddCache();
-            boolean is_d = this.table instanceof BddCacheDataD[];
             boolean is_bi = this.table instanceof BddCacheDataBI[];
-            if (is_d) {
-                that.table = new BddCacheDataD[this.table.length];
-            } else if (is_bi) {
+            if (is_bi) {
                 that.table = new BddCacheDataBI[this.table.length];
             } else {
                 that.table = new BddCacheDataI[this.table.length];
@@ -7050,23 +7033,6 @@ public class JFactory extends BDDFactoryIntImpl {
         return cache;
     }
 
-    BddCache BddCacheD_init(int size) {
-        int n;
-
-        size = bdd_prime_gte(size);
-
-        BddCache cache = new BddCache();
-        cache.table = new BddCacheDataD[size];
-
-        for (n = 0; n < size; n++) {
-            cache.table[n] = new BddCacheDataD();
-            cache.table[n].a = -1;
-        }
-        cache.tablesize = size;
-
-        return cache;
-    }
-
     BddCache BddCacheBI_init(int size) {
         int n;
 
@@ -7100,7 +7066,6 @@ public class JFactory extends BDDFactoryIntImpl {
         int n;
 
         boolean is_bi = cache.table instanceof BddCacheDataBI[];
-        boolean is_d = cache.table instanceof BddCacheDataD[];
 
         cache.table = null;
 
@@ -7108,8 +7073,6 @@ public class JFactory extends BDDFactoryIntImpl {
 
         if (is_bi) {
             cache.table = new BddCacheDataBI[newsize];
-        } else if (is_d) {
-            cache.table = new BddCacheDataD[newsize];
         } else {
             cache.table = new BddCacheDataI[newsize];
         }
@@ -7117,8 +7080,6 @@ public class JFactory extends BDDFactoryIntImpl {
         for (n = 0; n < newsize; n++) {
             if (is_bi) {
                 cache.table[n] = new BddCacheDataBI();
-            } else if (is_d) {
-                cache.table[n] = new BddCacheDataD();
             } else {
                 cache.table[n] = new BddCacheDataI();
             }
@@ -7131,10 +7092,6 @@ public class JFactory extends BDDFactoryIntImpl {
 
     BddCacheDataI BddCache_lookupI(BddCache cache, int hash) {
         return (BddCacheDataI)cache.table[Math.abs(hash % cache.tablesize)];
-    }
-
-    BddCacheDataD BddCache_lookupD(BddCache cache, int hash) {
-        return (BddCacheDataD)cache.table[Math.abs(hash % cache.tablesize)];
     }
 
     BddCacheDataBI BddCache_lookupBI(BddCache cache, int hash) {

--- a/src/main/java/com/github/javabdd/JFactory.java
+++ b/src/main/java/com/github/javabdd/JFactory.java
@@ -6354,7 +6354,7 @@ public class JFactory extends BDDFactoryIntImpl {
         BddCacheDataBI entry;
 
         if (root < 2) {
-            return (root == 0) ? BigInteger.ZERO : BigInteger.ONE;
+            return BigInteger.valueOf(root);
         }
 
         entry = BddCache_lookupBI(countcache, SATCOUHASH(root));


### PR DESCRIPTION
- `BDD.pathCount`/`satCount` return a `BigInteger` rather than a `double`.
- The `countcache` now stores `BigInteger`s as well.
- Gives better precision for larger BDDs.
- Prevents wrong results for very large BDDs.

Fixes #67