### PR TITLE
#66 Adding callback mechanisms for saturation

### DIFF
--- a/src/main/java/com/github/javabdd/BDDFactory.java
+++ b/src/main/java/com/github/javabdd/BDDFactory.java
@@ -2193,7 +2193,7 @@ public abstract class BDDFactory {
          *
          * @param transition The index of the transition that was applied.
          */
-        public void accept(int transition);
+        public void invoke(int transition);
     }
 
     /**
@@ -2210,7 +2210,7 @@ public abstract class BDDFactory {
          * @param before The BDD to which the transition was applied.
          * @param after The resulting BDD after applying the transition.
          */
-        public void accept(int transition, T before, T after);
+        public void invoke(int transition, T before, T after);
     }
 
     /** The registered garbage collection statistics callbacks, or {@code null} if none registered. */

--- a/src/main/java/com/github/javabdd/BDDFactory.java
+++ b/src/main/java/com/github/javabdd/BDDFactory.java
@@ -2185,6 +2185,34 @@ public abstract class BDDFactory {
         public void continuous(int usedBddNodes, long opMiss);
     }
 
+    /** Saturation callback with simple information. */
+    @FunctionalInterface
+    public static interface SaturationSimpleCallback {
+        /**
+         * The callback function that is invoked after every transition application performed by saturation.
+         *
+         * @param transition The index of the transition that was applied.
+         */
+        public void accept(int transition);
+    }
+
+    /**
+     * Saturation callback with debug information, notably the BDDs before and after applying a transition.
+     *
+     * @param <T> The BDD representation type.
+     */
+    @FunctionalInterface
+    public static interface SaturationDebugCallback<T> {
+        /**
+         * The callback function that is invoked after every transition application performed by saturation.
+         *
+         * @param transition The index of the transition that was applied.
+         * @param before The BDD to which the transition was applied.
+         * @param after The resulting BDD after applying the transition.
+         */
+        public void accept(int transition, T before, T after);
+    }
+
     /** The registered garbage collection statistics callbacks, or {@code null} if none registered. */
     protected List<GCStatsCallback> gcCallbacks = null;
 
@@ -2292,6 +2320,23 @@ public abstract class BDDFactory {
         }
         continuousCallbacks.add(callback);
     }
+
+    /**
+     * Sets the callback function that is invoked after every transition application performed by saturation.
+     *
+     * @param callback The non-{@code null} callback function.
+     */
+    public abstract void setSaturationCallback(SaturationSimpleCallback callback);
+
+    /**
+     * Sets the callback function that is invoked after every transition application performed by saturation.
+     *
+     * @param callback The non-{@code null} callback function.
+     */
+    public abstract void setSaturationCallback(SaturationDebugCallback<BDD> callback);
+
+    /** Unsets the saturation callback function. */
+    public abstract void unsetSaturationCallback();
 
     /**
      * Unregister a garbage collection statistics callback.

--- a/src/main/java/com/github/javabdd/BDDFactoryIntImpl.java
+++ b/src/main/java/com/github/javabdd/BDDFactoryIntImpl.java
@@ -136,7 +136,7 @@ public abstract class BDDFactoryIntImpl extends BDDFactory {
 
     @Override
     public void setSaturationCallback(SaturationSimpleCallback callback) {
-        setSaturationCallback_impl((transition, before, after) -> callback.accept(transition));
+        setSaturationCallback_impl((transition, before, after) -> callback.invoke(transition));
     }
 
     @Override
@@ -144,7 +144,7 @@ public abstract class BDDFactoryIntImpl extends BDDFactory {
         setSaturationCallback_impl((transition, before, after) -> {
             BDD beforeBdd = makeBDD(before);
             BDD afterBdd = makeBDD(after);
-            callback.accept(transition, beforeBdd, afterBdd);
+            callback.invoke(transition, beforeBdd, afterBdd);
             beforeBdd.free();
             afterBdd.free();
         });

--- a/src/main/java/com/github/javabdd/BDDFactoryIntImpl.java
+++ b/src/main/java/com/github/javabdd/BDDFactoryIntImpl.java
@@ -132,6 +132,29 @@ public abstract class BDDFactoryIntImpl extends BDDFactory {
 
     protected abstract void printTable_impl(/* bdd */int v);
 
+    protected abstract void setSaturationCallback_impl(SaturationDebugCallback<Integer> callback);
+
+    @Override
+    public void setSaturationCallback(SaturationSimpleCallback callback) {
+        setSaturationCallback_impl((transition, before, after) -> callback.accept(transition));
+    }
+
+    @Override
+    public void setSaturationCallback(SaturationDebugCallback<BDD> callback) {
+        setSaturationCallback_impl((transition, before, after) -> {
+            BDD beforeBdd = makeBDD(before);
+            BDD afterBdd = makeBDD(after);
+            callback.accept(transition, beforeBdd, afterBdd);
+            beforeBdd.free();
+            afterBdd.free();
+        });
+    }
+
+    @Override
+    public void unsetSaturationCallback() {
+        setSaturationCallback_impl(null);
+    }
+
     public class IntBDD extends BDD {
         protected /* bdd */int v;
 

--- a/src/main/java/com/github/javabdd/JFactory.java
+++ b/src/main/java/com/github/javabdd/JFactory.java
@@ -4072,7 +4072,7 @@ public class JFactory extends BDDFactoryIntImpl {
                     PUSHREF(result);
                     int prevResult = result;
                     result = relnextUnion_rec(result, relations[i], result, vars[i]);
-                    saturationCallback.accept(i, prevResult, result);
+                    saturationCallback.invoke(i, prevResult, result);
                     POPREF(1);
                 }
 
@@ -4242,7 +4242,7 @@ public class JFactory extends BDDFactoryIntImpl {
                     PUSHREF(result);
                     int prevResult = result;
                     result = or_rec(PUSHREF(relnextIntersection_rec(result, relations[i], bound, vars[i])), result);
-                    saturationCallback.accept(i, prevResult, result);
+                    saturationCallback.invoke(i, prevResult, result);
                     POPREF(2);
                 }
 
@@ -4384,7 +4384,7 @@ public class JFactory extends BDDFactoryIntImpl {
                     PUSHREF(result);
                     int prevResult = result;
                     result = relprevUnion_rec(relations[i], result, result, vars[i]);
-                    saturationCallback.accept(i, prevResult, result);
+                    saturationCallback.invoke(i, prevResult, result);
                     POPREF(1);
                 }
 
@@ -4554,7 +4554,7 @@ public class JFactory extends BDDFactoryIntImpl {
                     PUSHREF(result);
                     int prevResult = result;
                     result = or_rec(PUSHREF(relprevIntersection_rec(relations[i], result, bound, vars[i])), result);
-                    saturationCallback.accept(i, prevResult, result);
+                    saturationCallback.invoke(i, prevResult, result);
                     POPREF(2);
                 }
 

--- a/src/main/java/com/github/javabdd/JFactory.java
+++ b/src/main/java/com/github/javabdd/JFactory.java
@@ -50,6 +50,15 @@ public class JFactory extends BDDFactoryIntImpl {
 
     static final boolean SWAPCOUNT = false;
 
+    /** The default saturation callback function that does nothing. */
+    private static final SaturationDebugCallback<Integer> DEFAULT_SATURATION_CALLBACK = (t, b, a) -> { };
+
+    /**
+     * The non-{@code null} saturation callback function that is invoked after every transition application performed by
+     * saturation.
+     */
+    private SaturationDebugCallback<Integer> saturationCallback = DEFAULT_SATURATION_CALLBACK;
+
     private JFactory() {
     }
 
@@ -4061,7 +4070,9 @@ public class JFactory extends BDDFactoryIntImpl {
 
                 for (int i = current; i < next; i++) {
                     PUSHREF(result);
+                    int prevResult = result;
                     result = relnextUnion_rec(result, relations[i], result, vars[i]);
+                    saturationCallback.accept(i, prevResult, result);
                     POPREF(1);
                 }
 
@@ -4229,7 +4240,9 @@ public class JFactory extends BDDFactoryIntImpl {
 
                 for (int i = current; i < next; i++) {
                     PUSHREF(result);
+                    int prevResult = result;
                     result = or_rec(PUSHREF(relnextIntersection_rec(result, relations[i], bound, vars[i])), result);
+                    saturationCallback.accept(i, prevResult, result);
                     POPREF(2);
                 }
 
@@ -4369,7 +4382,9 @@ public class JFactory extends BDDFactoryIntImpl {
 
                 for (int i = current; i < next; i++) {
                     PUSHREF(result);
+                    int prevResult = result;
                     result = relprevUnion_rec(relations[i], result, result, vars[i]);
+                    saturationCallback.accept(i, prevResult, result);
                     POPREF(1);
                 }
 
@@ -4537,7 +4552,9 @@ public class JFactory extends BDDFactoryIntImpl {
 
                 for (int i = current; i < next; i++) {
                     PUSHREF(result);
+                    int prevResult = result;
                     result = or_rec(PUSHREF(relprevIntersection_rec(relations[i], result, bound, vars[i])), result);
+                    saturationCallback.accept(i, prevResult, result);
                     POPREF(2);
                 }
 
@@ -4558,6 +4575,11 @@ public class JFactory extends BDDFactoryIntImpl {
         entry.res = result;
 
         return result;
+    }
+
+    @Override
+    protected void setSaturationCallback_impl(SaturationDebugCallback<Integer> callback) {
+        saturationCallback = callback == null ? DEFAULT_SATURATION_CALLBACK : callback;
     }
 
     int relprod_rec(int l, int r) {


### PR DESCRIPTION
Closes #66.

This PR contributes a callback mechanism for the saturation operations that allows, e.g., printing debug information or checking for termination requests, after every transition application performed by saturation.

The callback mechanism works using functional interfaces. There are currently two callback types: 'simple' ones and 'debug' ones. The difference is that 'simple' doesn't create and free BDD nodes, and can thus be used when BDD information is not relevant (e.g., when a debug flag is not enabled). This may then save some performance.